### PR TITLE
Add null and non-positive time checks in calculate_data

### DIFF
--- a/custom_components/bermuda/__init__.py
+++ b/custom_components/bermuda/__init__.py
@@ -476,8 +476,14 @@ class BermudaDeviceScanner(dict):
                         # (skip the first entry since it's what we're comparing with)
                         continue
 
+                    if self.hist_stamp[i] is None:
+                        continue  # Skip this iteration if hist_stamp[i] is None
+
                     delta_t = velo_newstamp - self.hist_stamp[i]
                     delta_d = velo_newdistance - old_distance
+                    if delta_t <= 0:
+                        continue  # Additionally, skip if delta_t is zero or negative to avoid division by zero
+
                     velocity = delta_d / delta_t
 
                     # Approach velocities are only interesting vs the previous


### PR DESCRIPTION
In the calculate_data function within the __init__.py, two additional checks have been incorporated into the processing loop. The first check skips the iteration if the hist_stamp[i] is None, avoiding errors when accessing uninitialized data. The second check ensures the iteration is skipped if the time difference delta_t is zero or negative, which helps prevent division by zero errors when calculating velocity. These improvements enhance the reliability of the data calculation function by preventing potential crashes and errors during execution.